### PR TITLE
Better Non-ascii URL Parse

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,5 @@ require "redirect_follow_get"
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start
+require "pry"
+Pry.start

--- a/lib/redirect_follow_get.rb
+++ b/lib/redirect_follow_get.rb
@@ -6,9 +6,11 @@ require 'net/http'
 module RedirectFollowGet
   class TooManyRedirects < StandardError; end
 
-  def self.parse_url(url)
-    url = Addressable::URI.encode(url) unless url.ascii_only?
-    URI.parse(url)
+  class << self
+    def parse_url(url)
+      url = Addressable::URI.parse(url).normalize.to_s unless url.ascii_only?
+      URI.parse(url)
+    end
   end
 end
 

--- a/lib/redirect_follow_get.rb
+++ b/lib/redirect_follow_get.rb
@@ -7,12 +7,8 @@ module RedirectFollowGet
   class TooManyRedirects < StandardError; end
 
   def self.parse_url(url)
-    return URI.parse(url) if url.ascii_only?
-    Addressable::URI.parse(url).normalize
-  rescue URI::InvalidURIError
-    # if InvalidURIError is raised in URI.parse(),
-    # fallback to Addressable::URI.parse() method.
-    Addressable::URI.parse(url).normalize
+    url = Addressable::URI.encode(url) unless url.ascii_only?
+    URI.parse(url)
   end
 end
 

--- a/lib/redirect_follow_get.rb
+++ b/lib/redirect_follow_get.rb
@@ -15,7 +15,7 @@ module RedirectFollowGet
 end
 
 def redirect_follow_get(url, limit: 10)
-  raise RedirectFollowGet::TooManyRedirects, 'too many HTTP redirects' if limit.zero?
+  raise RedirectFollowGet::TooManyRedirects, 'too many HTTP redirects' unless limit > 0
 
   uri = RedirectFollowGet.parse_url(url)
 

--- a/test/redirect_follow_get_test.rb
+++ b/test/redirect_follow_get_test.rb
@@ -59,5 +59,6 @@ class RedirectFollowGetTest < Minitest::Test
     uri = "http://はじめよう.みんな/"
     r = redirect_follow_get(uri)
     assert_equal "200", r.code
+    assert_equal "http://xn--p8j9a0d9c9a.xn--q9jyb4c/index.html", r.uri.to_s
   end
 end

--- a/test/redirect_follow_get_test.rb
+++ b/test/redirect_follow_get_test.rb
@@ -54,4 +54,10 @@ class RedirectFollowGetTest < Minitest::Test
     r = redirect_follow_get(uri)
     assert_equal "200", r.code
   end
+
+  def test_non_ascii_url
+    uri = "http://はじめよう.みんな/"
+    r = redirect_follow_get(uri)
+    assert_equal "200", r.code
+  end
 end

--- a/test/redirect_follow_get_test.rb
+++ b/test/redirect_follow_get_test.rb
@@ -49,9 +49,8 @@ class RedirectFollowGetTest < Minitest::Test
     assert_equal "200", r.code
   end
 
-  # FIXME: dont know why I got 404
   def test_return_200_with_query_param2
-    uri = "https://www.instagram.com/p/BPBe5kOABuk/?tagged"
+    uri = "https://www.instagram.com/p/BPBe5kOABuk/?tagged=タグ"
     r = redirect_follow_get(uri)
     assert_equal "200", r.code
   end


### PR DESCRIPTION
resolves #4

- IDNA domain handling
- Can I use `Addressable::URI.normalized_encode` ?
  - but it does not `normalized_host`.